### PR TITLE
[BUGFIX] Avoid warning when accessing array offset on int

### DIFF
--- a/Classes/FormEngine/Elements/History.php
+++ b/Classes/FormEngine/Elements/History.php
@@ -56,10 +56,10 @@ class History extends AbstractNode
         }
 
         $languageId = 0;
-        if (array_key_exists('0', (array)$this->data['databaseRow']['sys_language_uid']) &&
-            $this->data['databaseRow']['sys_language_uid'][0]
-        ) {
+        if (is_array($this->data['databaseRow']['sys_language_uid']) && ($this->data['databaseRow']['sys_language_uid'][0] ?? false)) {
             $languageId = (int)$this->data['databaseRow']['sys_language_uid'][0];
+        } elseif (is_numeric($this->data['databaseRow']['sys_language_uid'])) {
+            $languageId = (int)$this->data['databaseRow']['sys_language_uid'];
         }
 
         $resultArray = $this->initializeResultArray();


### PR DESCRIPTION
On PHP 8 I got this error:

PHP Warning: Trying to access array offset on value of type int in /var/www/html/public/typo3conf/ext/page_speed_insights/Classes/FormEngine/Elements/History.php line 60

The patch fixes this. I haven't got an array in my tests, but an int with `0` and a string with `"0"`, so used the `is_numeric()` check.