### PR TITLE
[BUGFIX] Avoid undefined array key when using an offline workspace

### DIFF
--- a/Classes/Utility/PageSpeedInsightsUtility.php
+++ b/Classes/Utility/PageSpeedInsightsUtility.php
@@ -187,7 +187,7 @@ class PageSpeedInsightsUtility
             ->execute()
             ->fetch();
 
-        return (string)$data['reference'];
+        return (string)($data['reference'] ?? '-');
     }
 
     /**
@@ -325,8 +325,6 @@ class PageSpeedInsightsUtility
             ->where(...$conditions)
             ->execute()
             ->fetch();
-
-        list($mode, $tstamp) = GeneralUtility::trimExplode('-', $lastRun);
 
         return (int)$data['avg'];
     }


### PR DESCRIPTION
The following error is thrown with PHP 8 when accessing the page properties in an offline workspace:

    PHP Warning: Trying to access array offset on value of type bool in /var/www/html/vendor/haassie/page-speed-insights/Classes/Utility/PageSpeedInsightsUtility.php line 190

Additionally, a superfluous call in method getLastScore() has been removed as the variables are not used.